### PR TITLE
[SC test]: Add the comment about the cause of the error (= `Failed to open data file for writing: "./target/test_verifyProof.proof/proof"`)

### DIFF
--- a/test/circuit/Starter.t.sol
+++ b/test/circuit/Starter.t.sol
@@ -21,10 +21,12 @@ contract StarterTest is Test {
     }
 
     function test_verifyProof() public {
-        noirHelper.withInput("x", 1)
-                  .withInput("y", 1);
-                  //.withInput("nullifier", bytes32(uint256(0x0d550adf957548876e708338ed4e94a657a3ae4a99538d716faf422679df79d8)));
+        noirHelper.withInput("x", 3)
+                  .withInput("y", 3)
+                  .withInput("nullifier", bytes32(uint256(0x0d550adf957548876e708338ed4e94a657a3ae4a99538d716faf422679df79d8)));
                   //.withInput("return", bytes32(uint256(0x0d550adf957548876e708338ed4e94a657a3ae4a99538d716faf422679df79d8)));
+
+        /// @dev - [Error]: Failed to open data file for writing: "./target/test_verifyProof.proof/proof"
         (bytes32[] memory publicInputs, bytes memory proof) = noirHelper.generateProof("test_verifyProof", 2);
         starter.verifyEqual(proof, publicInputs);
     }
@@ -32,9 +34,11 @@ contract StarterTest is Test {
     function test_wrongProof() public {
         noirHelper.clean();
         noirHelper.withInput("x", 5)
-                  .withInput("y", 5);
-                  //.withInput("nullifier", bytes32(uint256(0x0d550adf957548876e708338ed4e94a657a3ae4a99538d716faf422679df79d8)));
+                  .withInput("y", 5)
+                  .withInput("nullifier", bytes32(uint256(0x0d550adf957548876e708338ed4e94a657a3ae4a99538d716faf422679df79d8)));
                   //.withInput("return", bytes32(uint256(0x0d550adf957548876e708338ed4e94a657a3ae4a99538d716faf422679df79d8)));
+
+        /// @dev - [Error]: Failed to open data file for writing: "./target/test_verifyProof.proof/proof"
         (bytes32[] memory publicInputs, bytes memory proof) = noirHelper.generateProof("test_wrongProof", 2);
 
         /// @dev - Create a fake public input, which should fail because the public input is wrong


### PR DESCRIPTION
## This can be resolved by fixing the `path`

- This can be resolved by fixing the `path` by referencing the following PR
    https://github.com/0xnonso/foundry-noir-helper/pull/6/commits/2912bc7f9c2d745949dee93ff8189cebb666a7f5